### PR TITLE
Fix GetInfrastructureProviderByName

### DIFF
--- a/controllers/infraprovider/helpers.go
+++ b/controllers/infraprovider/helpers.go
@@ -35,7 +35,7 @@ import (
 func (r *InfrastructureProviderReconciler) reconcileExternal(ctx context.Context, ip *machinev1.InfrastructureProvider, ref *corev1.ObjectReference) (*unstructured.Unstructured, error) {
 	logger := r.Log.WithValues("infraprovider", ip.Name, "namespace", ip.Namespace)
 
-	obj, err := external.Get(ctx, r.Client, ref, ip.Namespace)
+	obj, err := external.Get(ctx, r.Client, ref, ref.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(errors.Cause(err)) {
 			return nil, errors.Wrapf(&mapierrors.RequeueAfterError{RequeueAfter: r.externalReadyWait},

--- a/util/util.go
+++ b/util/util.go
@@ -69,7 +69,7 @@ func GetMachineByName(ctx context.Context, c client.Client, namespace, name stri
 func GetOwnerInfrastructureProvider(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*machinev1.InfrastructureProvider, error) {
 	for _, ref := range obj.OwnerReferences {
 		if ref.Kind == "InfrastructureProvider" && ref.APIVersion == machinev1.GroupVersion.String() {
-			return GetInfrastructureProviderByName(ctx, c, obj.Namespace, ref.Name)
+			return GetInfrastructureProviderByName(ctx, c, ref.Name)
 		}
 	}
 	return nil, nil
@@ -77,9 +77,9 @@ func GetOwnerInfrastructureProvider(ctx context.Context, c client.Client, obj me
 
 // GetInfrastructureProviderByName finds and return a InfrastructureProvider
 // object using the specified params.
-func GetInfrastructureProviderByName(ctx context.Context, c client.Client, namespace, name string) (*machinev1.InfrastructureProvider, error) {
+func GetInfrastructureProviderByName(ctx context.Context, c client.Client, name string) (*machinev1.InfrastructureProvider, error) {
 	ip := &machinev1.InfrastructureProvider{}
-	key := client.ObjectKey{Name: name, Namespace: namespace}
+	key := client.ObjectKey{Name: name}
 	if err := c.Get(ctx, key, ip); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The InfrastructureProvider resource is cluster scoped, but the specific implementations referenced are not.