### PR TITLE
Support resources created lazily by infra providers

### DIFF
--- a/api/v1alpha1/machine_types.go
+++ b/api/v1alpha1/machine_types.go
@@ -77,7 +77,7 @@ type MachineSpec struct {
 	// InfrastructureRef is a required reference to a custom resource offered
 	// by an infrastructure provider.
 	// +optional
-	InfrastructureRef corev1.ObjectReference `json:"infrastructureRef,omitempty"`
+	InfrastructureRef *corev1.ObjectReference `json:"infrastructureRef,omitempty"`
 
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -354,7 +354,11 @@ func (in *MachineList) DeepCopyObject() runtime.Object {
 func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 	*out = *in
 	out.ConfigRef = in.ConfigRef
-	out.InfrastructureRef = in.InfrastructureRef
+	if in.InfrastructureRef != nil {
+		in, out := &in.InfrastructureRef, &out.InfrastructureRef
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	if in.ProviderID != nil {
 		in, out := &in.ProviderID, &out.ProviderID
 		*out = new(string)

--- a/config/crd/bases/machine.crit.sh_configs.yaml
+++ b/config/crd/bases/machine.crit.sh_configs.yaml
@@ -24,14 +24,10 @@ spec:
       description: Config is the Schema for the configs API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -39,15 +35,12 @@ spec:
           description: ConfigSpec defines the desired state of CritConfig
           properties:
             config:
-              description: Config refers to either a crit ControlPlaneConfiguration
-                or WorkerConfiguration.
+              description: Config refers to either a crit ControlPlaneConfiguration or WorkerConfiguration.
               type: string
             files:
-              description: Files specifies extra files to be passed to user_data upon
-                creation.
+              description: Files specifies extra files to be passed to user_data upon creation.
               items:
-                description: File defines the input for generating write_files in
-                  cloud-init.
+                description: File defines the input for generating write_files in cloud-init.
                 properties:
                   content:
                     description: Content is the actual content of the file.
@@ -63,12 +56,10 @@ spec:
                     description: Owner specifies the ownership of the file, e.g. "root:root".
                     type: string
                   path:
-                    description: Path specifies the full path on disk where to store
-                      the file.
+                    description: Path specifies the full path on disk where to store the file.
                     type: string
                   permissions:
-                    description: Permissions specifies the permissions to assign to
-                      the file, e.g. "0640".
+                    description: Permissions specifies the permissions to assign to the file, e.g. "0640".
                     type: string
                 required:
                 - content
@@ -93,25 +84,21 @@ spec:
                   type: array
               type: object
             postCritCommands:
-              description: PostCritCommands specifies extra commands to run after
-                crit runs
+              description: PostCritCommands specifies extra commands to run after crit runs
               items:
                 type: string
               type: array
             preCritCommands:
-              description: PreCritCommands specifies extra commands to run before
-                crit runs
+              description: PreCritCommands specifies extra commands to run before crit runs
               items:
                 type: string
               type: array
             secrets:
-              description: Secrets specifies extra files that are sensitive so content
-                is stored separately in secrets.
+              description: Secrets specifies extra files that are sensitive so content is stored separately in secrets.
               items:
                 properties:
                   dataSecretName:
-                    description: DataSecretName is the name of the secret that stores
-                      the file content.
+                    description: DataSecretName is the name of the secret that stores the file content.
                     type: string
                   encoding:
                     description: Encoding specifies the encoding of the file contents.
@@ -124,17 +111,13 @@ spec:
                     description: Owner specifies the ownership of the file, e.g. "root:root".
                     type: string
                   path:
-                    description: Path specifies the full path on disk where to store
-                      the file.
+                    description: Path specifies the full path on disk where to store the file.
                     type: string
                   permissions:
-                    description: Permissions specifies the permissions to assign to
-                      the file, e.g. "0640".
+                    description: Permissions specifies the permissions to assign to the file, e.g. "0640".
                     type: string
                   secretKeyName:
-                    description: SecretKeyName is the key of the secret where the
-                      content is stored. Can only be a alphanumeric characters, '-',
-                      '_' or '.'.
+                    description: SecretKeyName is the key of the secret where the content is stored. Can only be a alphanumeric characters, '-', '_' or '.'.
                     type: string
                 required:
                 - dataSecretName
@@ -154,15 +137,13 @@ spec:
                     description: Groups specifies the additional groups for the user
                     type: string
                   homeDir:
-                    description: HomeDir specifies the home directory to use for the
-                      user
+                    description: HomeDir specifies the home directory to use for the user
                     type: string
                   inactive:
                     description: Inactive specifies whether to mark the user as inactive
                     type: boolean
                   lockPassword:
-                    description: LockPassword specifies if password login should be
-                      disabled
+                    description: LockPassword specifies if password login should be disabled
                     type: boolean
                   name:
                     description: Name specifies the user name
@@ -171,15 +152,13 @@ spec:
                     description: Passwd specifies a hashed password for the user
                     type: string
                   primaryGroup:
-                    description: PrimaryGroup specifies the primary group for the
-                      user
+                    description: PrimaryGroup specifies the primary group for the user
                     type: string
                   shell:
                     description: Shell specifies the user's shell
                     type: string
                   sshAuthorizedKeys:
-                    description: SSHAuthorizedKeys specifies a list of ssh authorized
-                      keys for the user
+                    description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
                     items:
                       type: string
                     type: array
@@ -197,8 +176,7 @@ spec:
           description: ConfigStatus defines the observed state of Config
           properties:
             dataSecretName:
-              description: DataSecretName is the name of the secret that stores the
-                bootstrap data script.
+              description: DataSecretName is the name of the secret that stores the bootstrap data script.
               type: string
             failureMessage:
               description: FailureMessage will be set on non-retryable errors
@@ -207,8 +185,7 @@ spec:
               description: FailureReason will be set on non-retryable errors
               type: string
             ready:
-              description: Ready indicates the BootstrapData field is ready to be
-                consumed
+              description: Ready indicates the BootstrapData field is ready to be consumed
               type: boolean
           type: object
       type: object

--- a/config/crd/bases/machine.crit.sh_infrastructureproviders.yaml
+++ b/config/crd/bases/machine.crit.sh_infrastructureproviders.yaml
@@ -35,18 +35,13 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: InfrastructureProvider is the Schema for the infrastructureproviders
-        API
+      description: InfrastructureProvider is the Schema for the infrastructureproviders API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -54,45 +49,13 @@ spec:
           description: InfrastructureProviderSpec defines the desired state of InfrastructureProvider
           properties:
             infrastructureRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
+              description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
               properties:
                 apiVersion:
                   description: API version of the referent.
                   type: string
                 fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
+                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                   type: string
                 kind:
                   description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -104,8 +67,7 @@ spec:
                   description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'

--- a/config/crd/bases/machine.crit.sh_machines.yaml
+++ b/config/crd/bases/machine.crit.sh_machines.yaml
@@ -43,14 +43,10 @@ spec:
       description: Machine is the Schema for the machines API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -58,24 +54,13 @@ spec:
           description: MachineSpec defines the desired state of Machine
           properties:
             configRef:
-              description: ConfigRef is a reference to the ConfigMap containing the
-                crit configuration used for this machine.
+              description: ConfigRef is a reference to the ConfigMap containing the crit configuration used for this machine.
               properties:
                 apiVersion:
                   description: API version of the referent.
                   type: string
                 fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
+                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                   type: string
                 kind:
                   description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -87,37 +72,23 @@ spec:
                   description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
             failureDomain:
-              description: FailureDomain is the failure domain the machine will be
-                created in. Must match a key in the FailureDomains map stored on the
-                cluster object.
+              description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
               type: string
             infrastructureRef:
-              description: InfrastructureRef is a required reference to a custom resource
-                offered by an infrastructure provider.
+              description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
               properties:
                 apiVersion:
                   description: API version of the referent.
                   type: string
                 fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
+                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                   type: string
                 kind:
                   description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -129,8 +100,7 @@ spec:
                   description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -143,8 +113,7 @@ spec:
           description: MachineStatus defines the observed state of Machine
           properties:
             addresses:
-              description: Addresses is a list of addresses assigned to the machine.
-                This field is copied from the infrastructure provider reference.
+              description: Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.
               items:
                 description: MachineAddress contains information for the node's address.
                 properties:
@@ -152,8 +121,7 @@ spec:
                     description: The machine address.
                     type: string
                   type:
-                    description: Machine address type, one of Hostname, ExternalIP
-                      or InternalIP.
+                    description: Machine address type, one of Hostname, ExternalIP or InternalIP.
                     type: string
                 required:
                 - address
@@ -161,38 +129,13 @@ spec:
                 type: object
               type: array
             failureMessage:
-              description: "FailureMessage will be set in the event that there is
-                a terminal problem reconciling the Machine and will contain a more
-                verbose string suitable for logging and human consumption. \n This
-                field should not be set for transitive errors that a controller faces
-                that are expected to be fixed automatically over time (like service
-                outages), but instead indicate that something is fundamentally wrong
-                with the Machine's spec or the configuration of the controller, and
-                that manual intervention is required. Examples of terminal errors
-                would be invalid combinations of settings in the spec, values that
-                are unsupported by the controller, or the responsible controller itself
-                being critically misconfigured. \n Any transient errors that occur
-                during the reconciliation of Machines can be added as events to the
-                Machine object and/or logged in the controller's output."
+              description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
               type: string
             failureReason:
-              description: "FailureReason will be set in the event that there is a
-                terminal problem reconciling the Machine and will contain a succinct
-                value suitable for machine interpretation. \n This field should not
-                be set for transitive errors that a controller faces that are expected
-                to be fixed automatically over time (like service outages), but instead
-                indicate that something is fundamentally wrong with the Machine's
-                spec or the configuration of the controller, and that manual intervention
-                is required. Examples of terminal errors would be invalid combinations
-                of settings in the spec, values that are unsupported by the controller,
-                or the responsible controller itself being critically misconfigured.
-                \n Any transient errors that occur during the reconciliation of Machines
-                can be added as events to the Machine object and/or logged in the
-                controller's output."
+              description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
               type: string
             infrastructureReady:
-              description: InfrastructureReady is the state of the infrastructure
-                provider.
+              description: InfrastructureReady is the state of the infrastructure provider.
               type: boolean
             lastUpdated:
               description: LastUpdated identifies when this status was last observed.
@@ -205,17 +148,7 @@ spec:
                   description: API version of the referent.
                   type: string
                 fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
+                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                   type: string
                 kind:
                   description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -227,22 +160,17 @@ spec:
                   description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
             phase:
-              description: Phase represents the current phase of machine actuation.
-                E.g. Pending, Running, Terminating, Failed etc. Phase string `json:"phase,omitempty"`
+              description: Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc. Phase string `json:"phase,omitempty"`
               type: string
             version:
-              description: Version specifies the current version of Kubernetes running
-                on the corresponding Node. This is meant to be a means of bubbling
-                up status from the Node to the Machine. It is entirely optional, but
-                useful for end-user UX if it’s present.
+              description: Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it’s present.
               type: string
           type: object
       type: object

--- a/controllers/csrapprover/validate.go
+++ b/controllers/csrapprover/validate.go
@@ -133,6 +133,9 @@ func (r *CSRApproverReconciler) getMachine(ctx context.Context, nodeName string)
 			continue
 		}
 		if nodeName == m.Status.NodeRef.Name {
+			if !m.Status.InfrastructureReady {
+				return nil, errors.Errorf("infrastructure for machine %q is not yet ready", m.Name)
+			}
 			return &m, nil
 		}
 	}

--- a/controllers/machine/helpers.go
+++ b/controllers/machine/helpers.go
@@ -159,7 +159,7 @@ func (w writer) Write(p []byte) (n int, err error) {
 }
 
 func (r *MachineReconciler) reconcileDeleteExternal(ctx context.Context, m *machinev1.Machine) error {
-	obj, err := external.Get(ctx, r.Client, &m.Spec.InfrastructureRef, m.Namespace)
+	obj, err := external.Get(ctx, r.Client, m.Spec.InfrastructureRef, m.Namespace)
 	if err != nil && !apierrors.IsNotFound(errors.Cause(err)) {
 		return errors.Wrapf(err, "failed to get InfrastructureRef %q for Machine %q in namespace %q", m.Spec.InfrastructureRef.Name, m.Name, m.Namespace)
 	}

--- a/controllers/machine/infraref.go
+++ b/controllers/machine/infraref.go
@@ -32,8 +32,13 @@ import (
 
 // reconcileInfrastructure reconciles the Spec.InfrastructureRef object on a Machine.
 func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, m *machinev1.Machine) error {
+	if m.Spec.InfrastructureRef == nil {
+		r.Log.Info("infrastructure reference is empty", "machine", m.Name)
+		return nil
+	}
+
 	// Call generic external reconciler.
-	infraReconcileResult, err := r.reconcileExternal(ctx, m, &m.Spec.InfrastructureRef)
+	infraReconcileResult, err := r.reconcileExternal(ctx, m, m.Spec.InfrastructureRef)
 	if err != nil {
 		if m.Status.InfrastructureReady && strings.Contains(err.Error(), "could not find") {
 			// Infra object went missing after the machine was up and running

--- a/controllers/node/controller.go
+++ b/controllers/node/controller.go
@@ -90,7 +90,7 @@ func (r *NodeReconciler) ensureMachineForNode(ctx context.Context, n *corev1.Nod
 		return err
 	}
 	for _, m := range machines.Items {
-		if m.Spec.ProviderID != nil && *m.Spec.ProviderID == n.Spec.ProviderID {
+		if m.Spec.ProviderID != nil && *m.Spec.ProviderID != "" && *m.Spec.ProviderID == n.Spec.ProviderID {
 			log.V(1).Info("node already has a machine associated with it, only needs an annotation")
 			return r.setMachineAnnotation(ctx, &m, n.Name)
 		}
@@ -105,7 +105,9 @@ func (r *NodeReconciler) ensureMachineForNode(ctx context.Context, n *corev1.Nod
 		},
 	}
 	if err := r.Create(ctx, m); err != nil {
-		return err
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
 	}
 	return r.setMachineAnnotation(ctx, m, n.Name)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -27,7 +27,12 @@ func MachineToInfrastructureMapFunc(gvk schema.GroupVersionKind) handler.ToReque
 		}
 
 		gk := gvk.GroupKind()
+
 		// Return early if the GroupKind doesn't match what we expect.
+
+		if m.Spec.InfrastructureRef == nil {
+			return nil
+		}
 		infraGK := m.Spec.InfrastructureRef.GroupVersionKind().GroupKind()
 		if gk != infraGK {
 			return nil


### PR DESCRIPTION
This changes the InfrastructureRef field to be a pointer to more easily check for existence.  This will help support the use case for infrastructure providers to create resources lazily in response to node creation events (i.e. when not expressly declared by the user).